### PR TITLE
update image-rs library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0-or-later"
 name = "jpegxl-rs"
 readme = "README.md"
 repository = "https://github.com/inflation/jpegxl-rs"
-version = "0.6.1"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,7 +21,7 @@ threads = ["jpegxl-sys/threads"]
 
 [dependencies]
 derive_builder = "0.10.2"
-image = { version = "0.23.14", optional = true, default-features = false }
+image = { version = "0.24.0", optional = true, default-features = false }
 jpegxl-sys = "0.6.1"
 paste = "1.0.5"
 thiserror = "1.0.30"
@@ -29,7 +29,7 @@ thiserror = "1.0.30"
 [dev-dependencies]
 anyhow = "1.0.45"
 criterion = { version = "0.3.5", features = ["html_reports"] }
-image = { version = "0.23.14", default-features = false, features = [
+image = { version = "0.24.0", default-features = false, features = [
 	"jpeg",
 	"png",
 ] }


### PR DESCRIPTION
Because the new version of image-rs (0.24.0) change the DynamicImage path, it can't be used with lower versions.