### PR TITLE
Remove path dependency on jpegxl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ thiserror = "1.0.31"
 
 [dependencies.jpegxl-sys]
 version = "0.6.2-alpha0"
-path = "../jpegxl-sys"
 
 [dev-dependencies]
 anyhow = "1.0.57"


### PR DESCRIPTION
Your master branch isn't compiling when I try to include it by `git="https://github.com/inflation/jpegxl-rs.git"`

Suggestion: for your own development purposes, use Cargo's [path-overrides feature](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#paths-overrides).