### PR TITLE
Support metadata encoding

### DIFF
--- a/jpegxl-rs/src/encode.rs
+++ b/jpegxl-rs/src/encode.rs
@@ -119,7 +119,7 @@ impl<'data> Metadata<'data> {
             exif: None,
             xmp: None,
             jumb: None,
-            compress: false
+            compress: false,
         }
     }
 
@@ -444,10 +444,15 @@ impl JxlEncoder<'_, '_> {
     }
 
     // Add box
-    fn add_box(&self, box_contents: &[u8], box_type: BoxTypes, compress: bool) -> Result<(), EncodeError> {
+    fn add_box(
+        &self,
+        box_contents: &[u8],
+        box_type: BoxTypes,
+        compress: bool,
+    ) -> Result<(), EncodeError> {
         let mut box_type = match box_type {
             BoxTypes::Exif => [69, 120, 105, 102],
-            BoxTypes::Xmp  => [120, 109, 108, 32],
+            BoxTypes::Xmp => [120, 109, 108, 32],
             BoxTypes::Jumb => [106, 117, 109, 98],
         };
         self.check_enc_status(unsafe {
@@ -462,7 +467,7 @@ impl JxlEncoder<'_, '_> {
     }
 
     // Add metadata
-    fn add_metadata(&self, metadata: Metadata) -> Result<(), EncodeError>  {
+    fn add_metadata(&self, metadata: Metadata) -> Result<(), EncodeError> {
         self.check_enc_status(unsafe { JxlEncoderUseBoxes(self.enc) })?;
         let compress = metadata.compress;
         if let Some(data) = metadata.exif {

--- a/jpegxl-rs/src/encode.rs
+++ b/jpegxl-rs/src/encode.rs
@@ -654,6 +654,23 @@ impl<'prl, 'mm> JxlEncoder<'prl, 'mm> {
         self.add_frame(frame)?;
         self.start_encoding::<U>()
     }
+
+    /// Encode a JPEG XL image from a frame with metadata. See [`EncoderFrame`] for custom options of the original pixels.
+    ///
+    /// # Errors
+    /// Return [`EncodeError`] if the internal encoder fails to encode
+    pub fn encode_frame_with_metadata<T: PixelType, U: PixelType>(
+        &mut self,
+        frame: &EncoderFrame<T>,
+        width: u32,
+        height: u32,
+        metadata: Metadata,
+    ) -> Result<EncoderResult<U>, EncodeError> {
+        self.setup_encoder(width, height, U::bits_per_sample(), self.has_alpha)?;
+        self.add_frame(frame)?;
+        self.add_metadata(metadata)?;
+        self.start_encoding::<U>()
+    }
 }
 
 impl Drop for JxlEncoder<'_, '_> {

--- a/jpegxl-rs/src/encode.rs
+++ b/jpegxl-rs/src/encode.rs
@@ -95,8 +95,11 @@ impl From<ColorEncoding> for JxlColorEncoding {
 /// Encoding box types
 #[derive(Debug, Clone, Copy)]
 pub enum BoxTypes {
+    // "Exif", a box with EXIF metadata
     Exif,
+    // "xml ", a box with XML data, in particular XMP metadata
     Xmp,
+    // "jumb", a JUMBF superbox, which can contain boxes with different types of metadata inside
     Jumb,
 }
 


### PR DESCRIPTION
- Support encode with metadata
- Add `encode_with_box` to encode image with metadata

By default the encoder assumes no metadata boxes will be added according to [libjxl's API](https://libjxl.readthedocs.io/en/latest/api_encoder.html#_CPPv418JxlEncoderUseBoxesP10JxlEncoder). So metadata like EXIF data is missing when creating `jxl` from png image etc.

An example code to encode with EXIF data:
```rust
use std::io::Write;

use jpegxl_rs::encode::{EncoderResult, BoxTypes};
use jpegxl_rs::encoder_builder;
use image::io::Reader as ImageReader;

fn main() {
    let sample = ImageReader::open("sample.png").unwrap().decode().unwrap().to_rgb8();
    let mut encoder = encoder_builder().build().unwrap();

    let file = std::fs::File::open("sample.png").unwrap();
    let mut bufreader = std::io::BufReader::new(&file);
    let exifreader = exif::Reader::new();
    let exif = exifreader.read_from_container(&mut bufreader).unwrap();

    let buffer: EncoderResult<f32> = encoder.encode_with_box(&sample, sample.width(), sample.height(), exif.buf(), BoxTypes::Exif).unwrap();
    
    let mut file = std::fs::File::create("sample.jxl").unwrap();
    let _ = file.write(&buffer.data);
}

```