### PR TITLE
Explicitly configure libdir to lib

### DIFF
--- a/jpegxl-src/src/lib.rs
+++ b/jpegxl-src/src/lib.rs
@@ -32,7 +32,8 @@ pub fn build() {
         .define("JPEGXL_ENABLE_JNI", "OFF")
         .define("JPEGXL_ENABLE_SJPEG", "OFF")
         .define("JPEGXL_ENABLE_OPENEXR", "OFF")
-        .define("JPEGXL_ENABLE_JPEGLI", "OFF");
+        .define("JPEGXL_ENABLE_JPEGLI", "OFF")
+        .define("CMAKE_INSTALL_LIBDIR", "lib");
 
     let mut prefix = config.build();
     prefix.push("lib");


### PR DESCRIPTION
Without this setting static library 
is placed in lib or lib64 depending on platform