### PR TITLE
🐛 Fix build using windows msvc

### DIFF
--- a/jpegxl-src/src/lib.rs
+++ b/jpegxl-src/src/lib.rs
@@ -49,7 +49,12 @@ pub fn build() {
 
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
     println!("cargo:rustc-link-lib=c++");
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "freebsd")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_env = "msvc"
+    )))]
     println!("cargo:rustc-link-lib=stdc++");
 }
 


### PR DESCRIPTION
When I build on `x86_64-pc-windows-msvc` it failed:
```
LINK : fatal error LNK1181: cannot open input file 'stdc++.lib'
```

Linking `stdc++` Should be excluded for MSVC.
`c++.lib` is unnecessary, too.