### PR TITLE
⬆️ chore: Update jpegxl-rs, jpegxl-src, and jpegxl-sys versions

### DIFF
--- a/jpegxl-rs/Cargo.toml
+++ b/jpegxl-rs/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 name = "jpegxl-rs"
 readme = "README.md"
 repository = "https://github.com/inflation/jpegxl-rs"
-version = "0.10.3+libjxl-0.10.2"
+version = "0.10.4+libjxl-0.10.3"
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/jpegxl-src/Cargo.toml
+++ b/jpegxl-src/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-3-Clause"
 name = "jpegxl-src"
 readme = "README.md"
 repository = "https://github.com/inflation/jpegxl-rs"
-version = "0.10.4"
+version = "0.10.5"
 rust-version.workspace = true
 exclude = [
     "libjxl/third_party/libpng",

--- a/jpegxl-sys/Cargo.toml
+++ b/jpegxl-sys/Cargo.toml
@@ -9,7 +9,7 @@ links = "jxl"
 name = "jpegxl-sys"
 readme = "README.md"
 repository = "https://github.com/inflation/jpegxl-rs"
-version = "0.10.3+libjxl-0.10.2"
+version = "0.10.4+libjxl-0.10.3"
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/jpegxl-sys/src/lib.rs
+++ b/jpegxl-sys/src/lib.rs
@@ -84,8 +84,8 @@ mod test {
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_bindings_version() {
         unsafe {
-            assert_eq!(JxlDecoderVersion(), 10002);
-            assert_eq!(JxlEncoderVersion(), 10002);
+            assert_eq!(JxlDecoderVersion(), 10003);
+            assert_eq!(JxlEncoderVersion(), 10003);
         }
     }
 


### PR DESCRIPTION
- `libjxl` v0.10.3