### PR TITLE
Set `JPEGXL_BUNDLE_LIBPNG` to `OFF`

### DIFF
--- a/jpegxl-src/src/lib.rs
+++ b/jpegxl-src/src/lib.rs
@@ -49,7 +49,8 @@ pub fn build() {
         .define("JPEGXL_ENABLE_JNI", "OFF")
         .define("JPEGXL_ENABLE_SJPEG", "OFF")
         .define("JPEGXL_ENABLE_OPENEXR", "OFF")
-        .define("JPEGXL_ENABLE_JPEGLI", "OFF");
+        .define("JPEGXL_ENABLE_JPEGLI", "OFF")
+        .define("JPEGXL_BUNDLE_LIBPNG", "OFF");
 
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
`JPEGXL_BUNDLE_LIBPNG ` defaults to be `true` if the target is `emscripten`, then cmake will throw an error because `libjxl/third_party/libpng` is excluded.


libjxl/CMakeLists.txt:

```cmake
if((SANITIZER STREQUAL "msan") OR EMSCRIPTEN)
  set(BUNDLE_LIBPNG_DEFAULT YES)

set(JPEGXL_BUNDLE_LIBPNG ${BUNDLE_LIBPNG_DEFAULT} CACHE BOOL
```

libjxl/third_party/CMakeLists.txt:

```cmake
if (JPEGXL_BUNDLE_LIBPNG AND EMSCRIPTEN)
  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libpng/CMakeLists.txt")
  message(FATAL_ERROR "Please run ${PROJECT_SOURCE_DIR}/deps.sh to fetch the "
          "build dependencies.")
```
