### PR TITLE
Change JxlBoxType to use system char type

### DIFF
--- a/jpegxl-rs/src/encode/metadata.rs
+++ b/jpegxl-rs/src/encode/metadata.rs
@@ -19,6 +19,6 @@ pub enum Metadata<'d> {
 impl Metadata<'_> {
     #[must_use]
     pub(crate) fn box_type(t: [u8; 4]) -> JxlBoxType {
-        JxlBoxType(unsafe { std::mem::transmute::<[u8; 4], [i8; 4]>(t) })
+        JxlBoxType(unsafe { std::mem::transmute::<[u8; 4], [std::ffi::c_char; 4]>(t) })
     }
 }


### PR DESCRIPTION
On Linux ARM64 machines, compilation fails with the following error:
```
error[E0308]: mismatched types
  --> jpegxl-rs/src/encode/metadata.rs:22:29
   |
22 |         JxlBoxType(unsafe { std::mem::transmute::<[u8; 4], [i8; 4]>(t) })
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; 4]`, found `[i8; 4]`
   |
   = note: expected array `[u8; 4]`
              found array `[i8; 4]`
```

The `JxlBoxType` is a new-type around `[std::ffi::c_char; 4]`. On many platforms, `std::ffi::c_char` is an `i8`. However, as the [docs](https://doc.rust-lang.org/stable/std/ffi/type.c_char.htm) state, some platforms will define `c_char` as a `u8`. Indeed, when looking at the [source](https://doc.rust-lang.org/1.80.1/src/core/ffi/mod.rs.html#83), we can see that linux/aarch64 (among other platforms) defines a `c_char` as `u8`.

The proposed solution simply changes the `transmute` call in `src/encode/metadata.rs` to target `c_char` instead of `i8`, so compilation succeeds regardless of whether `c_char` is defined as `u8` or `i8`.
