### PR TITLE
Don't use -sys in -rs with default features enabled

### DIFF
--- a/jpegxl-rs/Cargo.toml
+++ b/jpegxl-rs/Cargo.toml
@@ -38,6 +38,7 @@ byteorder = "1.5.0"
 [dependencies.jpegxl-sys]
 version = "0.10.3"
 path = "../jpegxl-sys"
+default-features = false
 
 [dev-dependencies]
 image = { version = "0.25.2", default-features = false, features = [


### PR DESCRIPTION
The -rs crate passes the features through one by one and enables them by default by having them in its default config. However, disabling features does not work, since -sys is always loaded with default features. Therefore disable default features for -sys and everything works as expected.

Closes #83 