### PR TITLE
Fix libstdc++ linking failure

### DIFF
--- a/jpegxl-src/src/lib.rs
+++ b/jpegxl-src/src/lib.rs
@@ -82,17 +82,13 @@ pub fn build() {
     println!("cargo:rustc-link-lib=static=brotlicommon");
     println!("cargo:rustc-link-lib=static=brotlidec");
     println!("cargo:rustc-link-lib=static=brotlienc");
-
-    #[cfg(feature = "threads")]
+    #[cfg(any(target_vendor = "apple", target_os = "freebsd"))]
     {
-        #[cfg(any(target_vendor = "apple", target_os = "freebsd"))]
-        {
-            println!("cargo:rustc-link-lib=c++");
-        }
-        #[cfg(target_os = "linux")]
-        {
-            println!("cargo:rustc-link-lib=stdc++");
-        }
+        println!("cargo:rustc-link-lib=c++");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=stdc++");
     }
 }
 


### PR DESCRIPTION
libjxl seems to always require libstdc++ on Linux.

It stopped working after doing cargo update. I think some dependency added the libstdc++ before because it was present in the linker command.

```
    error: linking with `cc` failed: exit status: 1
      |
      = note: LC_ALL="C" PATH="/usr/lib/rustlib/x86_64-unknown-linux-gnu/bin:/usr
/lib/rustlib/x86_64-unknown-linux-gnu/bin:/usr/lib/rustlib/x86_64-unknown-linux-g
nu/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/usr/libexec/
sdcc:/bin:/usr/libexec/sdcc" VSLANG="1033" "cc" "-m64" "/tmp/rustcS83rti/symbols.
o" [...] "/jpegxl-rs/target/debug/deps/test-486ba2ccd7d65513.cl29tktjbfxcjv68br7n
6ta9j.rcgu.o" "-Wl,--as-needed" "-L" "/jpegxl-rs/target/debug/deps" "-L" "/jpegxl
-rs/target/debug/build/jpegxl-sys-64a3ca069a8daa52/out/lib64" "-L" "/jpegxl-rs/ta
rget/debug/build/jpegxl-sys-64a3ca069a8daa52/out/lib64" "-L" "/usr/lib/rustlib/x8
6_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" [...] "/debug/deps/libanyhow-95c2b3767
bd2d142.rlib" "/usr/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-9da483f6b79c6
5fa.rlib" [...] "-Wl,-Bdynamic" "-llcms2" "-lhwy" "-lbrotlicommon" "-lbrotlidec" 
"-lbrotlienc" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-
frame-hdr" "-Wl,-z,noexecstack" "-L" "/usr/lib/rustlib/x86_64-unknown-linux-gnu/l
ib" "-o" "/jpegxl-rs/target/debug/deps/test-486ba2ccd7d65513" "-Wl,--gc-sections"
 "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
      = note: /usr/bin/ld: /debug/deps/libjpegxl_sys-fd5119eb917c3702.rlib(encode
.cc.o): undefined reference to symbol '_ZNSt7__cxx1112basic_stringIcSt11char_trai
tsIcESaIcEE13_S_copy_charsEPcPKcS7_@@GLIBCXX_3.4.21'
              /usr/bin/ld: /usr/lib64/libstdc++.so.6: error adding symbols: DSO m
issing from command line
              collect2: error: ld returned 1 exit status
    
      = note: some `extern` functions couldn't be found; some native libraries ma
y need to be installed or have their path specified
      = note: use the `-l` flag to specify native libraries to link
      = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)
    
    warning: `x` (bin "test") generated 8 warnings
    error: could not compile `x` (bin "test") due to 1 previous error; 8 warnings emitted
```