### PR TITLE
Fix `cargo doc`

### DIFF
--- a/jpegxl-rs/src/errors.rs
+++ b/jpegxl-rs/src/errors.rs
@@ -47,7 +47,7 @@ pub enum DecodeError {
     UnknownStatus(JxlDecoderStatus),
 }
 
-/// Errors derived from [`JxlEncoderStatus`][jpegxl_sys::encode::JxlEncoderStatus]
+/// Errors derived from [`JxlEncoderStatus`][jpegxl_sys::encoder::encode::JxlEncoderStatus]
 /// and [`JxlEncoderError`]
 #[derive(Error, Debug)]
 pub enum EncodeError {

--- a/jpegxl-rs/src/parallel/resizable_runner.rs
+++ b/jpegxl-rs/src/parallel/resizable_runner.rs
@@ -17,8 +17,6 @@ along with jpegxl-rs.  If not, see <https://www.gnu.org/licenses/>.
 
 //! Wrapper for resizable thread pool implementation with C++ standard library
 
-#![cfg_attr(docsrs, doc(cfg(feature = "threads")))]
-
 use std::{ffi::c_void, ptr::null_mut};
 
 use jpegxl_sys::threads::resizable_parallel_runner as api;

--- a/jpegxl-sys/src/encoder/encode.rs
+++ b/jpegxl-sys/src/encoder/encode.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 #[cfg(doc)]
-use crate::{    
+use crate::{
     common::types::{JxlBitDepthType, JxlDataType},
     encoder::stats::JxlEncoderStatsCreate,
 };

--- a/jpegxl-sys/src/encoder/encode.rs
+++ b/jpegxl-sys/src/encoder/encode.rs
@@ -31,9 +31,9 @@ use crate::{
 };
 
 #[cfg(doc)]
-use crate::{
-    encoder::stats::JxlEncoderStatsCreate,
+use crate::{    
     common::types::{JxlBitDepthType, JxlDataType},
+    encoder::stats::JxlEncoderStatsCreate,
 };
 
 /// Opaque structure that holds the JPEG XL encoder.

--- a/jpegxl-sys/src/encoder/encode.rs
+++ b/jpegxl-sys/src/encoder/encode.rs
@@ -31,9 +31,9 @@ use crate::{
 };
 
 #[cfg(doc)]
-use crate::common::{
+use crate::{
     encoder::stats::JxlEncoderStatsCreate,
-    types::{JxlBitDepthType, JxlDataType},
+    common::types::{JxlBitDepthType, JxlDataType},
 };
 
 /// Opaque structure that holds the JPEG XL encoder.
@@ -1281,7 +1281,7 @@ extern "C" {
     ) -> JxlEncoderStatus;
 
     /// Sets a frame-specific option of integer type to the encoder options.
-    /// The [`FrameSetting`] argument determines which option is set.
+    /// The [`JxlEncoderFrameSettingId`] argument determines which option is set.
     ///
     /// # Parameters
     /// - `frame_settings`: set of options and metadata for this frame. Also
@@ -1302,7 +1302,7 @@ extern "C" {
     ) -> JxlEncoderStatus;
 
     /// Sets a frame-specific option of float type to the encoder options.
-    /// The [`FrameSetting`] argument determines which option is set.
+    /// The [`JxlEncoderFrameSettingId`] argument determines which option is set.
     ///
     /// # Parameters
     /// - `frame_settings`: set of options and metadata for this frame. Also


### PR DESCRIPTION
Hi there,

It looks like the mass-renaming campaign from the latest release missed a few doc-specific includes and references, causing `docs.rs` and `cargo doc` to fail.

This PR should get the documentation working again.