### PR TITLE
fix: update extern "C" to extern "C-unwind" in multiple files

### DIFF
--- a/jpegxl-sys/src/color/cms.rs
+++ b/jpegxl-sys/src/color/cms.rs
@@ -19,6 +19,6 @@ along with jpegxl-sys.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::cms_interface::JxlCmsInterface;
 
-extern "C" {
+extern "C-unwind" {
     pub fn JxlGetDefaultCms() -> *const JxlCmsInterface;
 }

--- a/jpegxl-sys/src/color/cms_interface.rs
+++ b/jpegxl-sys/src/color/cms_interface.rs
@@ -28,7 +28,7 @@ use crate::common::types::JxlBool;
 
 use super::color_encoding::JxlColorEncoding;
 
-pub type JpegXlCmsSetFieldsFromIccFunc = extern "C" fn(
+pub type JpegXlCmsSetFieldsFromIccFunc = extern "C-unwind" fn(
     user_data: *mut c_void,
     icc_data: *const u8,
     icc_size: usize,
@@ -51,7 +51,7 @@ pub struct JxlColorProfile {
     pub num_channels: usize,
 }
 
-pub type JpegXlCmsInitFunc = extern "C" fn(
+pub type JpegXlCmsInitFunc = extern "C-unwind" fn(
     init_data: *mut c_void,
     num_threads: usize,
     pixels_per_thread: usize,
@@ -60,9 +60,10 @@ pub type JpegXlCmsInitFunc = extern "C" fn(
     intensity_target: f32,
 ) -> *mut c_void;
 
-pub type JpegXlCmsGetBufferFunc = extern "C" fn(user_data: *mut c_void, thread: usize) -> *mut f32;
+pub type JpegXlCmsGetBufferFunc =
+    extern "C-unwind" fn(user_data: *mut c_void, thread: usize) -> *mut f32;
 
-pub type JpegXlCmsRunFunc = extern "C" fn(
+pub type JpegXlCmsRunFunc = extern "C-unwind" fn(
     user_data: *mut c_void,
     thread: usize,
     input_buffer: *const f32,
@@ -70,7 +71,7 @@ pub type JpegXlCmsRunFunc = extern "C" fn(
     num_pixels: usize,
 ) -> JxlBool;
 
-pub type JpegXlCmsDestroyFun = extern "C" fn(user_data: *mut c_void);
+pub type JpegXlCmsDestroyFun = extern "C-unwind" fn(user_data: *mut c_void);
 
 #[repr(C)]
 #[derive(Debug, Clone)]

--- a/jpegxl-sys/src/decode.rs
+++ b/jpegxl-sys/src/decode.rs
@@ -360,7 +360,7 @@ pub type JxlImageOutRunCallback = extern "C" fn(
 /// - `run_opaque`: user data returned by the [`init`](JxlImageOutInitCallback) callback.
 pub type JxlImageOutDestroyCallback = extern "C" fn(run_opaque: *mut c_void);
 
-extern "C" {
+extern "C-unwind" {
     /// Decoder library version.
     ///
     /// # Returns

--- a/jpegxl-sys/src/encoder/encode.rs
+++ b/jpegxl-sys/src/encoder/encode.rs
@@ -565,7 +565,7 @@ pub type JxlDebugImageCallback = extern "C-unwind" fn(
     pixels: *const u16,
 );
 
-extern "C" {
+extern "C-unwind" {
     /// Encoder library version.
     ///
     /// # Returns

--- a/jpegxl-sys/src/encoder/stats.rs
+++ b/jpegxl-sys/src/encoder/stats.rs
@@ -29,7 +29,7 @@ pub struct JxlEncoderStats {
     _unused: [u8; 0],
 }
 
-extern "C" {
+extern "C-unwind" {
     /// Creates an instance of [`JxlEncoderStats`] and initializes it.
     ///
     /// # Returns

--- a/jpegxl-sys/src/metadata/compressed_icc.rs
+++ b/jpegxl-sys/src/metadata/compressed_icc.rs
@@ -19,7 +19,7 @@ along with jpegxl-sys.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::common::{memory_manager, types::JxlBool};
 
-extern "C" {
+extern "C-unwind" {
     /// Allocates a buffer using the memory manager, fills it with a compressed
     /// representation of an ICC profile, returns the result through `output_buffer`
     /// and indicates its size through `output_size`.

--- a/jpegxl-sys/src/metadata/gain_map.rs
+++ b/jpegxl-sys/src/metadata/gain_map.rs
@@ -60,7 +60,7 @@ pub struct JxlGainMapBundle {
     pub gain_map: *const u8,
 }
 
-extern "C" {
+extern "C-unwind" {
     /// Calculates the total size required to serialize the gain map bundle into a
     /// binary buffer. This function accounts for all the necessary space to
     /// serialize fields such as gain map metadata, color encoding, compressed ICC


### PR DESCRIPTION
This pull request fixes an issue by updating `extern "C"` to `extern "C-unwind"` in multiple files.