### PR TITLE
Fix default init_buffer_size to be 512 KiB

### DIFF
--- a/jpegxl-rs/src/encode.rs
+++ b/jpegxl-rs/src/encode.rs
@@ -153,7 +153,7 @@ impl<'prl, 'mm> JxlEncoderBuilder<'prl, 'mm> {
 
         let init_buffer_size =
             self.init_buffer_size
-                .map_or(512 * 1024 * 1024, |v| if v < 32 { 32 } else { v });
+                .map_or(512 * 1024, |v| if v < 32 { 32 } else { v });
 
         Ok(JxlEncoder {
             enc,


### PR DESCRIPTION
The docs specify that `init_buffer_size`'s default value is 512 KiB. However it's [actually 512 MiB](https://github.com/inflation/jpegxl-rs/blob/master/jpegxl-rs/src/encode.rs#L154) (512 * 1024 * 1024 == 512 MiB). This PR updates the docs. An alternative approach could be to change the default; I'm not sure which is better.