### PR TITLE
Frame header for encoder API

### DIFF
--- a/jpegxl-rs/src/encode.rs
+++ b/jpegxl-rs/src/encode.rs
@@ -312,9 +312,22 @@ impl JxlEncoder<'_, '_> {
 
     // Add a frame
     fn add_frame<T: PixelType>(&self, frame: &EncoderFrame<T>) -> Result<(), EncodeError> {
+        let options_ptr = if let Some(header) = frame.get_header() {
+            let ptr = unsafe { JxlEncoderFrameSettingsCreate(self.enc, self.options_ptr) };
+            if ptr.is_null() {
+                return Err(EncodeError::OutOfMemory);
+            }
+            unsafe {
+                JxlEncoderSetFrameHeader(ptr, header);
+            }
+            ptr
+        } else {
+            self.options_ptr
+        };
+
         self.check_enc_status(unsafe {
             JxlEncoderAddImageFrame(
-                self.options_ptr,
+                options_ptr,
                 &frame.pixel_format(),
                 frame.data.as_ptr().cast(),
                 std::mem::size_of_val(frame.data),
@@ -362,6 +375,9 @@ impl JxlEncoder<'_, '_> {
 
         unsafe { JxlEncoderReset(self.enc) };
         self.options_ptr = unsafe { JxlEncoderFrameSettingsCreate(self.enc, null()) };
+        if self.options_ptr.is_null() {
+            return Err(EncodeError::OutOfMemory);
+        }
 
         buffer.shrink_to_fit();
         Ok(buffer)

--- a/jpegxl-rs/src/lib.rs
+++ b/jpegxl-rs/src/lib.rs
@@ -33,6 +33,8 @@ pub mod image;
 #[cfg(test)]
 mod tests;
 
+pub use jpegxl_sys;
+
 pub use common::Endianness;
 pub use decode::decoder_builder;
 pub use encode::encoder_builder;


### PR DESCRIPTION
I tried adding frame header support. The current version only supports the encoder side.

A final version should probably include decoder support to.