### PR TITLE
fix: replace todo!() panics with NotImplemented errors

### DIFF
--- a/jpegxl-rs/src/decode.rs
+++ b/jpegxl-rs/src/decode.rs
@@ -285,7 +285,9 @@ impl JxlDecoder<'_, '_> {
                     self.output(unsafe { &*basic_info.as_ptr() }, data_type, format, pixels)?;
                 }
 
-                s::FullImage => {}
+                // Informational events - continue processing
+                s::FullImage | s::Frame | s::FrameProgression => {}
+
                 s::Success => {
                     if let Some(buf) = reconstruct_jpeg_buffer.as_mut() {
                         let remaining = unsafe { JxlDecoderReleaseJPEGBuffer(self.dec) };
@@ -310,13 +312,14 @@ impl JxlDecoder<'_, '_> {
                         icc_profile: icc,
                     });
                 }
-                s::NeedPreviewOutBuffer => todo!(),
-                s::BoxNeedMoreOutput => todo!(),
-                s::PreviewImage => todo!(),
-                s::Frame => todo!(),
-                s::Box => todo!(),
-                s::BoxComplete => todo!(),
-                s::FrameProgression => todo!(),
+                // Features not yet implemented in this wrapper
+                s::NeedPreviewOutBuffer => {
+                    return Err(DecodeError::NotImplemented("preview image output"))
+                }
+                s::BoxNeedMoreOutput => return Err(DecodeError::NotImplemented("box output")),
+                s::PreviewImage => return Err(DecodeError::NotImplemented("preview image")),
+                s::Box => return Err(DecodeError::NotImplemented("box handling")),
+                s::BoxComplete => return Err(DecodeError::NotImplemented("box complete")),
             }
         }
     }

--- a/jpegxl-rs/src/errors.rs
+++ b/jpegxl-rs/src/errors.rs
@@ -45,6 +45,9 @@ pub enum DecodeError {
     /// Unknown status
     #[error("Unknown status: `{0:?}`")]
     UnknownStatus(JxlDecoderStatus),
+    /// Feature not yet implemented in this wrapper
+    #[error("Feature not yet implemented: {0}")]
+    NotImplemented(&'static str),
 }
 
 /// Errors derived from [`JxlEncoderStatus`][jpegxl_sys::encoder::encode::JxlEncoderStatus]


### PR DESCRIPTION
## Summary

The decoder currently panics at runtime if certain decoder events occur (preview image, box handling, etc.) because these code paths use `todo!()` macros. This PR replaces those panics with proper `NotImplemented` errors, allowing graceful error handling.

## Changes

- Add `DecodeError::NotImplemented(&'static str)` variant for unsupported features
- Replace `todo!()` panics with `NotImplemented` errors in the decoder
- Combine informational decoder events (`FullImage`, `Frame`, `FrameProgression`) into a single match arm since they all just continue processing

## Before

```rust
s::NeedPreviewOutBuffer => todo!(),  // PANICS!
s::Box => todo!(),                    // PANICS!
```

## After

```rust
s::NeedPreviewOutBuffer => return Err(DecodeError::NotImplemented("preview image output"))
s::Box => return Err(DecodeError::NotImplemented("box handling"))
```

## Testing

All existing tests pass (29 tests).