### PR TITLE
feat: add #[non_exhaustive] to error enums

### DIFF
--- a/jpegxl-rs/src/errors.rs
+++ b/jpegxl-rs/src/errors.rs
@@ -23,6 +23,7 @@ use jpegxl_sys::{decode::JxlDecoderStatus, encoder::encode::JxlEncoderError};
 
 /// Errors derived from [`JxlDecoderStatus`]
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// Cannot create a decoder
     #[error("Cannot create a decoder")]
@@ -50,6 +51,7 @@ pub enum DecodeError {
 /// Errors derived from [`JxlEncoderStatus`][jpegxl_sys::encoder::encode::JxlEncoderStatus]
 /// and [`JxlEncoderError`]
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum EncodeError {
     /// Cannot create an encoder
     #[error("Cannot create an encoder")]


### PR DESCRIPTION
## Summary

Marks `DecodeError` and `EncodeError` as `#[non_exhaustive]` to allow adding new error variants in future versions without breaking downstream code.

Closes #179

## Why

This is a [Rust API Guidelines best practice](https://rust-lang.github.io/api-guidelines/future-proofing.html) for public error enums. Without it, adding a new variant (like `NotImplemented` in #175) would be a breaking change requiring a semver major bump.

## Changes

```rust
#[derive(Error, Debug)]
#[non_exhaustive]  // Added
pub enum DecodeError { ... }

#[derive(Error, Debug)]
#[non_exhaustive]  // Added
pub enum EncodeError { ... }
```

## Impact

Downstream users with exhaustive matches will need to add a wildcard arm:

```rust
match err {
    DecodeError::GenericError => ...,
    // ...
    _ => ..., // Now required
}
```

This is technically a breaking change, but a minor one that improves long-term API stability.