### PR TITLE
ci: add Linux and Windows aarch64 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add ARM64 runners to the test matrix:
- `ubuntu-24.04-arm` for Linux aarch64
- `windows-11-arm` for Windows aarch64

This ensures the library builds and passes tests on ARM64, which is increasingly important for:
- AWS Graviton instances
- Azure Cobalt / Arm-based VMs
- Docker on Apple Silicon
- Windows on ARM devices (Surface Pro X, etc.)
- Raspberry Pi and other ARM SBCs
- Ampere Altra servers

Tested on imazen/jpegxl-rs fork - all platforms pass CI.